### PR TITLE
Use model imposed by rh2 for document

### DIFF
--- a/demo/adobesign/models.py
+++ b/demo/adobesign/models.py
@@ -69,6 +69,9 @@ class Signature(django_anysign.SignatureFactory(SignatureType)):
         Part of `django_anysign`'s API implementation.
 
         """
+        # For compliance with other signature backends
+        # Will be removed in major version
+        self.document.bytes = self.document
         yield self.document
 
     def __str__(self):

--- a/django_adobesign/client.py
+++ b/django_adobesign/client.py
@@ -81,13 +81,13 @@ class AdobeSignClient(object):
     def upload_document(self, document):
         url = self.build_url(urlpath='transientDocuments')
         data = {
-            'File-Name': basename(document.file.name),
+            'File-Name': basename(document.name),
             'Mime-Type': 'application/pdf'
         }
         try:
             response = requests.post(url,
                                      headers=self.get_headers(),
-                                     files={'File': document},
+                                     files={'File': document.bytes},
                                      data=data)
             response.raise_for_status()
         except (requests.exceptions.RequestException, HTTPError) as e:

--- a/django_adobesign/tests/test_adobe_client.py
+++ b/django_adobesign/tests/test_adobe_client.py
@@ -1,6 +1,4 @@
 import pytest
-from django.core.files import File
-from django.db.models import FileField
 from requests import Response
 
 from django_adobesign.client import AdobeSignOAuthSession, \
@@ -95,9 +93,9 @@ def test_should_get_jsonified_participant(adobe_sign_client,
 
 @pytest.fixture()
 def test_document(mocker):
-    document = mocker.Mock(FileField)
-    document.file = mocker.Mock(File)
-    document.file.name = '/tmp/test_document.pdf'
+    document = mocker.Mock()
+    document.name = '/tmp/test_document.pdf'
+    document.bytes = b''
     return document
 
 
@@ -115,7 +113,7 @@ def test_call_upload_document(mocker, adobe_sign_client, expected_headers,
 
     kwargs_params = mocked_post.call_args[1]
     assert kwargs_params == {'headers': expected_headers,
-                             'files': {'File': test_document},
+                             'files': {'File': test_document.bytes},
                              'data': expected_data}
 
 


### PR DESCRIPTION
This commit should be revert if we handle to remove rh2 Document model dependency.
https://github.com/peopledoc/RH2/blob/021c1d838d4996aaace516c599ba2f32d9c10234/rh2/apps/signature/models.py#L710

This is also the case in other backends which implement Anysign