### PR TITLE
Confirm Django 2.2 compatibility

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,7 +8,7 @@ about future releases, check `milestones`_ and :doc:`/about/vision`.
 0.7 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Confirm compatibility with Django 2.2
 
 
 0.6 (2019-03-20)

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ README = open(os.path.join(here, 'README.rst')).read()
 VERSION = open(os.path.join(here, 'VERSION')).read().strip()
 
 REQUIREMENTS = [
-    'Django>=1.11,<2.2',
+    'Django>=1.11,<2.3',
     'django-anysign>=1.2',
     'requests',
     # v1.2.0 introduce OAuthlib 3.0.0 seems to be not compatible with Adobe
@@ -33,6 +33,7 @@ if __name__ == '__main__':  # Do not run setup() when we import this module.
             'Framework :: Django :: 1.11',
             'Framework :: Django :: 2.0',
             'Framework :: Django :: 2.1',
+            'Framework :: Django :: 2.2',
             "Programming Language :: Python :: 2",
             "Programming Language :: Python :: 2.7",
             "Programming Language :: Python :: 3",

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     py{27,35,36}-django111
-    py{35,36,37}-django{20,21}
+    py{35,36,37}-django{20,21,22}
     flake8
     readme
 


### PR DESCRIPTION
TODO : Tests do not cover `django_adobesign.views.SignerReturnView`.