### PR TITLE
Catch and raise api max rate limit

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,7 @@ about future releases, check `milestones`_ and :doc:`/about/vision`.
 ----------------
 
 - Add a default timeout to 15 seconds to the client
+- Catch and raise AdobeSign API max rate limit
 
 
 


### PR DESCRIPTION
Api max rate limit from AdobeSign is catched and raised