### PR TITLE
Update Django to use security patched version

### DIFF
--- a/demo/setup.py
+++ b/demo/setup.py
@@ -15,7 +15,7 @@ README = open(os.path.join(here, 'README.rst')).read()
 VERSION = open(os.path.join(project_root, 'VERSION')).read().strip()
 
 REQUIREMENTS = [
-    'Django>=1.11,<2.1',
+    'Django~=2.2.16',
     'django-anysign>=1.2',
     'requests',
     'requests_oauthlib',
@@ -35,10 +35,10 @@ if __name__ == '__main__':  # Do not run setup() when we import this module.
             'Framework :: Django',
             'Framework :: Django :: 1.11',
             'Framework :: Django :: 2.0',
-            "Programming Language :: Python :: 2",
-            "Programming Language :: Python :: 2.7",
             "Programming Language :: Python :: 3",
             "Programming Language :: Python :: 3.6",
+            "Programming Language :: Python :: 3.7",
+            "Programming Language :: Python :: 3.8",
         ],
         keywords='peopledoc anysign adobesign',
         author='Peopledoc',

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ README = open(os.path.join(here, 'README.rst')).read()
 VERSION = open(os.path.join(here, 'VERSION')).read().strip()
 
 REQUIREMENTS = [
-    'Django>=1.11,<2.3',
+    'Django~=2.2.16',
     'django-anysign>=1.2',
     'requests',
     # v1.2.0 introduce OAuthlib 3.0.0 seems to be not compatible with Adobe
@@ -30,15 +30,11 @@ if __name__ == '__main__':  # Do not run setup() when we import this module.
         classifiers=[
             "Operating System :: POSIX",
             'Framework :: Django',
-            'Framework :: Django :: 1.11',
-            'Framework :: Django :: 2.0',
-            'Framework :: Django :: 2.1',
             'Framework :: Django :: 2.2',
-            "Programming Language :: Python :: 2",
-            "Programming Language :: Python :: 2.7",
             "Programming Language :: Python :: 3",
             "Programming Language :: Python :: 3.6",
             "Programming Language :: Python :: 3.7",
+            "Programming Language :: Python :: 3.8",
         ],
         keywords='peopledoc anysign adobesign',
         author='Peopledoc',

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ passenv =
     OPENTRUST_ROOT_URL
 usedevelop = True
 deps =
-    django22: Django~=2.2.0
+    django22: Django~=2.2.16
     coverage
     pytest
     pytest-django


### PR DESCRIPTION
Django version under 2.2.13 have multiple security issues.
This PR set 2.2.16 <= Django <2.3