### PR TITLE
Add oauth webhook scopes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,7 +7,7 @@ about future releases, check `milestones`_ and :doc:`/about/vision`.
 0.13 (unreleased)
 -----------------
 
-- Nothing changed yet
+- Add oauth scopes for webhooks
 
 
 0.12 (2022-12-05)

--- a/django_adobesign/client.py
+++ b/django_adobesign/client.py
@@ -32,7 +32,9 @@ class AdobeSignOAuthSession(object):
             'user_login:{}',
             'agreement_send:{}',
             'agreement_read:{}',
-            'agreement_write:{}')]
+            'agreement_write:{}',
+            'webhook_write:{}',
+            'webhook_read:{}')]
 
     def create_token(self, code, application_secret):
         response = self.oauth_session.fetch_token(

--- a/django_adobesign/tests/test_adobe_client.py
+++ b/django_adobesign/tests/test_adobe_client.py
@@ -30,6 +30,8 @@ def test_oauth_get_scopes():
     assert 'agreement_send:account' in scopes
     assert 'agreement_read:account' in scopes
     assert 'agreement_write:account' in scopes
+    assert 'webhook_write:account' in scopes
+    assert 'webhook_read:account' in scopes
 
 
 def test_oauth_create(mocker, adobe_oauth_session):


### PR DESCRIPTION
To be able to handle adobesign webhooks, we need to add two scopes.
`webhook_write` allows to call /webhooks to create webhooks
`webhook_read` allows to get webhooks configuration, which is not super useful but might be handy at times.